### PR TITLE
Proper deb creation and entitlements fix

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -24,6 +24,10 @@ jobs:
 #          clang -fpic -shared -Wl,-all_load libprism_common.a -o libprism_common.dylib
 #          clang -fpic -shared -Wl,-all_load libprism_es2.a -o libprism_es2.dylib
 
+      - name: Setup Dependencies
+        run: |
+          brew install ldid dpkg fakeroot
+
       - name: Native build
         run: |
           cd Natives
@@ -47,15 +51,15 @@ jobs:
           
       - name: Sign and Package IPA
         run: |
-          mkdir Payload
-          cp -R Natives/build/Release-iphoneos/PojavLauncher.app Payload/
-          brew install ldid
-          ldid -Sentitlements.xml Payload/PojavLauncher.app/PojavLauncher
-          zip -r PojavLauncher.ipa Payload
+          mkdir -p packages/pojavlauncher_iphoneos-arm/{DEBIAN,Applications,var/lib/pojavlauncher}
+          cp -R Natives/build/Release-iphoneos/PojavLauncher.app packages/pojavlauncher_iphoneos-arm/Applications
+          cp control packages/pojavlauncher_iphoneos-arm/DEBIAN
+          ldid -Sentitlements.xml packages/pojavlauncher_iphoneos-arm/Applications/PojavLauncher.app
+          fakeroot dpkg-deb -b packages/pojavlauncher_iphoneos-arm
           
       - name: Upload IPA
         uses: actions/upload-artifact@v2
         with:
-          name: PojavLauncher
-          path: PojavLauncher.ipa
+          name: PojavLauncher deb
+          path: packages/pojavlauncher_iphoneos-arm.deb
 

--- a/control
+++ b/control
@@ -1,0 +1,8 @@
+Package: pojavlauncher
+Maintainer: DuyKhanhTran
+Architecture: iphoneos-arm
+Version: 1.0
+Depends: openjdk-16-jre
+Section: Games
+Priority: optional
+Description: Minecraft: Java Edition launcher for iOS, based on PojavLauncher Android.

--- a/entitlements.xml
+++ b/entitlements.xml
@@ -2,7 +2,7 @@
 <plist version="1.0">
 <dict>
     <key>com.apple.private.security.container-required</key>
-    <false/>
+    <true/>
     <key>com.apple.security.exception.files.absolute-path.read-write</key>
     <array>
 	    <string>/</string>


### PR DESCRIPTION
You should now be able to easily install the deb by doing `dpkg -i pojavlauncher_iphoneos-arm.deb` on your device, if you have openjdk-16-jre installed. I have ensured the entitlements and permissions are all correct. This does not fix the crash at startup, but eliminates possible future problems.