### PR TITLE
Text changes, in the app and out.

### DIFF
--- a/Natives/LauncherViewController.m
+++ b/Natives/LauncherViewController.m
@@ -43,14 +43,14 @@ UITextField* versionTextField;
     }
 
     UILabel *versionTextView = [[UILabel alloc] initWithFrame:CGRectMake(4.0, 4.0, 0.0, 30.0)];
-    versionTextView.text = @"Minecraft version:";
+    versionTextView.text = @"Minecraft version: ";
     versionTextView.numberOfLines = 0;
     [versionTextView sizeToFit];
     [scrollView addSubview:versionTextView];
 
     versionTextField = [[UITextField alloc] initWithFrame:CGRectMake(versionTextView.bounds.size.width + 4.0, 4.0, width - versionTextView.bounds.size.width - 8.0, versionTextView.bounds.size.height)];
     [versionTextField addTarget:versionTextField action:@selector(resignFirstResponder) forControlEvents:UIControlEventEditingDidEndOnExit];
-    versionTextField.placeholder = @"Minecraft version";
+    versionTextField.placeholder = @"Specify version...";
     versionTextField.text = [NSString stringWithUTF8String:configver];
     fclose(configver_file);
     [scrollView addSubview:versionTextField];

--- a/README.md
+++ b/README.md
@@ -81,6 +81,15 @@ chmod 755 *.sh
 - Add Doregon's repository (https://doregon.github.io/cydia)
 - Find and install `openjdk-16-jre`.
 
+## Installing PojavLauncher
+### For Chimera/Odyssey/Taurine jailbreak 
+- Add Procursus repository (https://apt.procurs.us) (usually the Sileo package manager already comes with Procursus repo).
+- Find and install `pojavlauncher`.
+
+### For other jailbreak bootstraps
+- Add Doregon's repository (https://doregon.github.io/cydia)
+- Find and install `pojavlauncher` for the release version, or `pojavlauncher-dev` for the latest good commit.
+    
 ## Directory locations
 - Account json directory: `/var/mobile/Documents/.pojavlauncher/accounts`.
 - Minecraft home directory: `/var/mobile/Documents/minecraft`.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ chmod 755 *.sh
 - Add Doregon's repository (https://doregon.github.io/cydia)
 - Find and install `openjdk-16-jre`.
 
+### Manual
+- Download [openjdk-16-jre.deb](https://github.com/PojavLauncherTeam/PojavLauncher_iOS/releases/tag/v16-openjdk).
+- Install and open Filza File manager.
+- Go to where the .deb file downloaded.
+- Open it and press Install.
+- If everything fine, it will ends up with `Setting up ...`.
+
 ## Installing PojavLauncher
 ### For Chimera/Odyssey/Taurine jailbreak 
 - Add Procursus repository (https://apt.procurs.us) (usually the Sileo package manager already comes with Procursus repo).
@@ -89,7 +96,19 @@ chmod 755 *.sh
 ### For other jailbreak bootstraps
 - Add Doregon's repository (https://doregon.github.io/cydia)
 - Find and install `pojavlauncher` for the release version, or `pojavlauncher-dev` for the latest good commit.
-    
+
+### Manual
+- To get the release version, 
+    - Go to the Releases tab
+    - Find the release you want
+    - Download the .deb file
+    - Open the .deb in Filza or install via a terminal!
+
+- To get the latest commit,
+    - Download the latest build artifact from [here](https://nightly.link/PojavLauncherTeam/PojavLauncher_iOS/workflows/ios/main/PojavLauncher%20deb.zip)
+    - Unzip to reveal the .deb file
+    - Open the .deb in Filza or install via a terminal!
+     
 ## Directory locations
 - Account json directory: `/var/mobile/Documents/.pojavlauncher/accounts`.
 - Minecraft home directory: `/var/mobile/Documents/minecraft`.

--- a/README.md
+++ b/README.md
@@ -73,16 +73,13 @@ chmod 755 *.sh
 - It might crash sometimes, but try launch again until you get it works.
 
 ## Installing OpenJDK 16
-### For Chimera/Odyssey/Taurine jailbreak
-- Add Procursus repository (https://apt.procurs.us) (usually Sileo package manager already come with Procursus repo).
-- Find and install `openjdk-jre`.
+### For Chimera/Odyssey/Taurine jailbreak 
+- Add Procursus repository (https://apt.procurs.us) (usually the Sileo package manager already comes with Procursus repo).
+- Find and install `openjdk-16-jre`.
 
-### For other jailbreak bootstrap
-- Download [openjdk-16-jre.deb](https://github.com/PojavLauncherTeam/PojavLauncher_iOS/releases/tag/v16-openjdk).
-- Install and open Filza File manager.
-- Go to where the .deb file downloaded.
-- Open it and press Install.
-- If everything fine, it will ends up with `Setting up ...`.
+### For other jailbreak bootstraps
+- Add Doregon's repository (https://doregon.github.io/cydia)
+- Find and install `openjdk-16-jre`.
 
 ## Directory locations
 - Account json directory: `/var/mobile/Documents/.pojavlauncher/accounts`.

--- a/control
+++ b/control
@@ -2,7 +2,8 @@ Package: pojavlauncher
 Maintainer: DuyKhanhTran
 Architecture: iphoneos-arm
 Version: 1.1
-Depends: openjdk-16-jre
+Depends: openjdk-16-jre, firmware (>= 12.0)
+Conflicts: pojavlauncher-dev
 Section: Games
 Priority: optional
 Homepage: https://github.com/PojavLauncherTeam/PojavLauncher_iOS


### PR DESCRIPTION
- In the app, the version select screen is a little bit nicer. Instead of something like `Minecraft version:1.16.5` (where the version is hugging the text), it’ll add a space to be like `Minecraft version: 1.16.5`.
- Due to how I decided to provide two different copies of PojavLauncher on my repository instead of one, I added a line in the control script so it conflicts with the Dev build on my repository. It also requires iOS 12, which is stated.
- I updated the Readme with information on my repository and manual installation, and fixed up some of the wording as well.

If there’s anything I need to change/undo, feel free to let me know.