### PR TITLE
Adding a jetsam bypass

### DIFF
--- a/Natives/JavaLauncher.c
+++ b/Natives/JavaLauncher.c
@@ -5,7 +5,7 @@
 #include <pthread.h>
 #include <unistd.h>
 #include <string.h>
-
+#include <spawn.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 
@@ -21,6 +21,8 @@
 static const char *java_libs_dir = "/Applications/PojavLauncher.app/libs";
 static const char *args_path = "/var/mobile/Documents/.pojavlauncher/overrideargs.txt";
 static const char *log_path = "/var/mobile/Documents/minecraft/latestlog.txt";
+
+extern char **environ;
 
 static const char* const_progname = "java";
 static const char* const_launcher = "openjdk";
@@ -100,6 +102,28 @@ int launchJVM(int argc, char *argv[]) {
         dup2(log_fd, 1);
         dup2(log_fd, 2);
         close(log_fd);
+    }
+
+    /* iOS jetsam memory bypass. This is going to launch with the JVM so it fires correctly.
+     * To prevent centering PojavLauncher around my repository, this is completely optional.
+     * When I release my revised version of jetsamctl, I'll update this section.
+     */
+    if( access("/usr/bin/jetsamctl", F_OK ) == 0 ) {
+        debug("[Pre-init] jetsamctl was found. Overriding memory limits.");
+        pid_t pid;
+        char *argv[] = {
+                "/usr/bin/sudo",
+                "/usr/bin/jetsamctl",
+                "-l",
+                "$(awk -v MEM=$(sysctl -a | grep memsize | cut -b 13-26) 'BEGIN { print  ( MEM / 1024 / 1024 ) }' | cut -b 1-4)",
+                "PojavLauncher",
+                NULL
+        };
+
+        posix_spawn(&pid, argv[0], NULL, NULL, argv, environ);
+        debug("[Pre-init] jetsamctl finished successfully.");
+    } else {
+        debug("[Pre-Init] jetsamctl was not found. If you wish to prevent jetsam-related crashes, get jetsamctl.");
     }
 
     debug("[Pre-init] Beginning JVM launch\n");


### PR DESCRIPTION
When using PojavLauncher iOS, jetsam can get in the way of some truly fantastic experiences. I was able to go all the way to 1GB dedicated to PojavLauncher—without crashing—on my 2GB SE. This jetsam bypass works with a package that I now host called jetsamctl (and will change to my revised version in the future) by sending a command when PojavLauncher starts to calculate the total memory and use this as the memory value.

This requires 0.2 of jetsamctl to be installed for proper functionality. The pull also has safegaurds to prevent centering around my repository—this is completely optional. If you don’t install jetsamctl 0.2 and run PojavLauncher, the log will notify you of this action.

This code was taken from my repository.