### PR TITLE
Time to move to the new Makefile

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -4,7 +4,7 @@ on:
   [push, workflow_dispatch]
 
 jobs:
-  build:
+  setup:
     runs-on: macOS-latest
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
@@ -15,17 +15,32 @@ jobs:
 
       - name: Setup Dependencies
         run: brew install ldid dpkg fakeroot
-
-      - name: Native build
-        run: bash scripts/build_natives.sh
-
-      - name: Java app Build
-        run: bash scripts/build_javaapp.sh
-          
-      - name: Sign and Package deb
-        run: bash scripts/build_package.sh
-          
-      - name: Upload IPA
+  native:
+    needs: setup
+    runs-on: macOS-latest
+    steps:
+      - name: Build the native application
+        run: make native
+  javaapp:
+    needs: setup
+    runs-on: macOS-latest
+    steps:
+      - name: Build the Java application
+        run: make java
+  extras:
+    needs: setup
+    runs-on: macOS-latest
+    steps:
+      - name: Build the extra stuff
+        run: make extras
+  package:
+    needs: [native, javaapp, extras]
+    runs-on: macOS-latest
+    steps:
+      - name: Package everything up
+        run: make package
+        
+      - name: Upload build artifact
         uses: actions/upload-artifact@v2
         with:
           name: PojavLauncher deb

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -9,12 +9,12 @@ jobs:
     runs-on: macOS-latest
     steps:
       - name: Set up build environment
-      - uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: '12.4.0'
           
       - name: Set up build environment pt. II
-      - uses: actions/checkout@v2
+        uses: actions/checkout@v2
       
       - name: Set up build environment pt. III
         run: brew install ldid dpkg fakeroot

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -4,16 +4,19 @@ on:
   [push, workflow_dispatch]
 
 jobs:
-  setup:
+  build:
+    name: The guts
     runs-on: macOS-latest
     steps:
+      - name: Set up build environment
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: '12.4.0'
-
+          
+      - name: Set up build environment pt. II
       - uses: actions/checkout@v2
-
-      - name: Setup Dependencies
+      
+      - name: Set up build environment pt. III
         run: brew install ldid dpkg fakeroot
         
       - name: Build the native application
@@ -22,10 +25,10 @@ jobs:
       - name: Build the Java application
         run: make java
 
-      - name: Build the extra stuff
+      - name: Build the assets and Storyboards
         run: make extras
 
-      - name: Package everything up
+      - name: Build the Debian package
         run: make package
         
       - name: Upload build artifact

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -15,35 +15,23 @@ jobs:
 
       - name: Setup Dependencies
         run: brew install ldid dpkg fakeroot
-  native:
-    needs: setup
-    runs-on: macOS-latest
-    steps:
+        
       - name: Build the native application
         run: make native
-  javaapp:
-    needs: setup
-    runs-on: macOS-latest
-    steps:
+
       - name: Build the Java application
         run: make java
-  extras:
-    needs: setup
-    runs-on: macOS-latest
-    steps:
+
       - name: Build the extra stuff
         run: make extras
-  package:
-    needs: [native, javaapp, extras]
-    runs-on: macOS-latest
-    steps:
+
       - name: Package everything up
         run: make package
         
       - name: Upload build artifact
         uses: actions/upload-artifact@v2
         with:
-          name: PojavLauncher deb
+          name: pojavlauncher_iphoneos-arm.deb
           path: packages/pojavlauncher_iphoneos-arm.deb
 
 

--- a/scripts/javaapp_aminimake.sh
+++ b/scripts/javaapp_aminimake.sh
@@ -5,6 +5,9 @@
 /bin/bash <<'EOF'
 
 set -e
+
+cd JavaApp
+
 shopt -s globstar
 
 mkdir -p local_out/classes

--- a/scripts/natives_aminimake.sh
+++ b/scripts/natives_aminimake.sh
@@ -5,6 +5,8 @@
 #!/bin/bash
 set -e
 
+cd Natives
+
 CFLAGS="-Wl,-rpath,/Applications/PojavLauncher.app/Frameworks -fobjc-arc -x objective-c -Fresources/Frameworks -Iresources/Frameworks/MetalANGLE.framework/Headers -isysroot /var/mobile/theos/sdks/iPhoneOS13.4.sdk"
 
 clang -framework UIKit $CFLAGS -o PojavLauncher main.c log.m JavaLauncher.c


### PR DESCRIPTION
### The guts of the pull.
It's finally time to switch over our build operations to the new Makefile! The end users of our beloved launcher probably won't see much of a difference, but the developers and those who build manually will! As of this pull request, the old scripts are still available (including the on-device ones!), just moved to the `scripts` directory on this repository. They should still compile, but we highly recommend testing and using the new Makefile. Here's how you can transition to the new build system:

| Original | Make | Supported build OS |
| --- | --- | --- |
| `build_natives.sh` (Obj-C compile) | `make native` | macOS + iOS |
| `build_natives.sh` (Assets and Storyboards) | `make extras` | macOS |
| `build_javaapp.sh` | `make java` | macOS + iOS |
| `build_package.sh` (Packaging) | `make package` | macOS + iOS |
| `build_package.sh` (Installation) | `make install` | macOS + iOS |
| `rm -rf build` (No script equivalent) | `make clean` | macOS + iOS |

### On iOS?
You can continue to build on iOS with this Makefile! You just need to make sure you have `clang`, `make`, `dpkg-dev`, `fakeroot`, `ldid`, and `openjdk-16-jre` installed to build. Here are important notes:

* `make extras` is disabled on iOS, as it is not possible to compile Assets.xcassets or any Storyboards without a Mac. When building a package on iOS, pre-compiled copies are used instead.
* You need to have an iOS SDK in order to compile. Check out [xybp888/iOS-SDKs](https://github.com/xybp888/iOS-SDKs) if you are in need. Unlike the macOS requirement, you'll need to use a 14.4 SDK or higher and place it in `/usr/share/SDKs/iPhoneOS.sdk` after installing Clang.