### PR TITLE
Move the variables to the plist

### DIFF
--- a/DEBIAN/control
+++ b/DEBIAN/control
@@ -4,7 +4,7 @@ Maintainer: PojavLauncherTeam <https://discord.gg/6RpEJda>
 Author: DuyKhanhTran
 Architecture: iphoneos-arm
 Version: 1.3
-Depends: openjdk-16-jre | openjdk-16-jdk | openjdk-8-jre | openjdk-8-jdk, firmware (>= 12.0)
+Depends: openjdk-8-jre | openjdk-16-jre | openjdk-8-jdk | openjdk-16-jdk, firmware (>= 12.0)
 Conflicts: pojavlauncher-dev, pojavlauncher-zink
 Section: Games
 Priority: optional

--- a/Natives/JavaLauncher.m
+++ b/Natives/JavaLauncher.m
@@ -58,8 +58,8 @@ static char* margv[1000];
 static int pfd[2];
 static pthread_t logger;
 
-char *javaHome;
-char *gl4esLibname;
+const char *javaHome;
+const char *gl4esLibname;
 NSString *javaHome_pre;
 NSString *gl4esLibname_pre;
 
@@ -169,7 +169,7 @@ int launchJVM(int argc, char *argv[]) {
             }
         } else {
             javaHome = calloc(1, 2048);
-            sprintf(javaHome, "%s/jre8", getenv("BUNDLE_PATH"));
+            sprintf((char *)javaHome, "%s/jre8", getenv("BUNDLE_PATH"));
         }
         setenv("JAVA_HOME", javaHome, 1);
         debug("[Pre-init] JAVA_HOME environment variable not set. Defaulting to %s\n", javaHome);

--- a/Natives/JavaLauncher.m
+++ b/Natives/JavaLauncher.m
@@ -174,8 +174,21 @@ int launchJVM(int argc, char *argv[]) {
         setenv("JAVA_HOME", javaHome, 1);
         debug("[Pre-init] JAVA_HOME environment variable was not set. Defaulting to %s for future use.\n", javaHome);
     } else {
-        javaHome = [javaHome_pre cStringUsingEncoding:NSUTF8StringEncoding];
-        debug("[Pre-Init] Restored preference: JAVA_HOME is set to %s\n", javaHome);
+        if (0 == [[NSFileManager defaultManager] fileExistsAtPath:javaHome_pre]) {
+            debug("[Pre-Init] Failed to locate %s. Restoring default value for JAVA_HOME.", javaHome);
+            if (0 != access("/usr/lib/jvm/java-8-openjdk/", F_OK)) {
+                debug("[Pre-init] Java 8 wasn't found on your device. Install Java 8 for more compatibility and the mod installer.");
+                javaHome_pre = @"/usr/lib/jvm/java-16-openjdk";
+                javaHome = [javaHome_pre cStringUsingEncoding:NSUTF8StringEncoding];
+                setPreference(@"java_home", javaHome_pre);
+            } else {
+                javaHome_pre = @"/usr/lib/jvm/java-8-openjdk";
+                javaHome = [javaHome_pre cStringUsingEncoding:NSUTF8StringEncoding];
+                setPreference(@"java_home", javaHome_pre);
+            }
+        } else {
+            debug("[Pre-Init] Restored preference: JAVA_HOME is set to %s\n", javaHome);
+        }
     }
 
     gl4esLibname_pre = getPreference(@"gl4es_libname");

--- a/Natives/JavaLauncher.m
+++ b/Natives/JavaLauncher.m
@@ -155,7 +155,7 @@ int launchJVM(int argc, char *argv[]) {
     setenv("LIBGL_NORMALIZE", "1", 1);
 
     javaHome_pre = getPreference(@"java_home");
-    if (!javaHome_pre) {
+    if ([javaHome_pre length] == 0) {
         if (strncmp(argv[0], "/Applications", 13) == 0) {
             if (0 != access("/usr/lib/jvm/java-8-openjdk/", F_OK)) {
                 debug("[Pre-init] Java 8 wasn't found on your device. Install Java 8 for more compatibility and the mod installer.");
@@ -179,7 +179,7 @@ int launchJVM(int argc, char *argv[]) {
     }
 
     gl4esLibname_pre = getPreference(@"gl4es_libname");
-    if (!gl4esLibname_pre) {
+    if ([gl4esLibname_pre length] == 0) {
         gl4esLibname_pre = @"libgl4es_114.dylib";
         setPreference(@"gl4es_libname", gl4esLibname_pre);
         gl4esLibname = [gl4esLibname_pre cStringUsingEncoding:NSUTF8StringEncoding];

--- a/Natives/JavaLauncher.m
+++ b/Natives/JavaLauncher.m
@@ -156,9 +156,9 @@ int launchJVM(int argc, char *argv[]) {
 
     javaHome_pre = getPreference(@"java_home");
     if (!javaHome_pre) {
-    if (strncmp(argv[0], "/Applications", 13) == 0) {
+        if (strncmp(argv[0], "/Applications", 13) == 0) {
             if (0 != access("/usr/lib/jvm/java-8-openjdk/", F_OK)) {
-                debug("[Pre-init] Java 8 wasn't found on your device.");
+                debug("[Pre-init] Java 8 wasn't found on your device. Install Java 8 for more compatibility and the mod installer.");
                 javaHome_pre = @"/usr/lib/jvm/java-16-openjdk";
                 javaHome = [javaHome_pre cStringUsingEncoding:NSUTF8StringEncoding];
                 setPreference(@"java_home", javaHome_pre);
@@ -172,20 +172,22 @@ int launchJVM(int argc, char *argv[]) {
             sprintf((char *)javaHome, "%s/jre8", getenv("BUNDLE_PATH"));
         }
         setenv("JAVA_HOME", javaHome, 1);
-        debug("[Pre-init] JAVA_HOME environment variable not set. Defaulting to %s\n", javaHome);
+        debug("[Pre-init] JAVA_HOME environment variable was not set. Defaulting to %s for future use.\n", javaHome);
     } else {
         javaHome = [javaHome_pre cStringUsingEncoding:NSUTF8StringEncoding];
+        debug("[Pre-Init] Restored preference: JAVA_HOME is set to %s\n", javaHome);
     }
 
     gl4esLibname_pre = getPreference(@"gl4es_libname");
     if (!gl4esLibname_pre) {
         gl4esLibname_pre = @"libgl4es_114.dylib";
         setPreference(@"gl4es_libname", gl4esLibname_pre);
-        gl4esLibname = [gl4esLibname_pre UTF8String];
+        gl4esLibname = [gl4esLibname_pre cStringUsingEncoding:NSUTF8StringEncoding];
         setenv("GL4ES_LIBNAME", gl4esLibname, 1);
-        debug("[Pre-init] GL4ES_LIBNAME environment variable was not set. Defaulting to %s\n", gl4esLibname);
+        debug("[Pre-init] GL4ES_LIBNAME environment variable was not set. Defaulting to %s for future use.\n", gl4esLibname);
     } else {
-        gl4esLibname = [gl4esLibname_pre UTF8String];
+        gl4esLibname = [gl4esLibname_pre cStringUsingEncoding:NSUTF8StringEncoding];
+        debug("[Pre-Init] Restored preference: GL4ES_LIBNAME is set to %s\n", gl4esLibname);
     }
 
     char controlPath[2048];
@@ -237,7 +239,7 @@ int launchJVM(int argc, char *argv[]) {
         margv[margc++] = "-Dorg.lwjgl.system.allocator=system";
     } else {
         setenv("GL4ES_LIBNAME", gl4esLibname, 1);
-        debug("[Pre-init] OpenGL library name: %s", getenv("GL4ES_LIBNAME"));
+        debug("[Pre-init] GL4ES_LIBNAME has been set to %s", getenv("GL4ES_LIBNAME"));
     }
 
     // Load java

--- a/Natives/JavaLauncher.m
+++ b/Natives/JavaLauncher.m
@@ -93,6 +93,60 @@ void init_migrateToPlist(char* prefKey, char* filename) {
     }
 }
 
+void init_checkPlist() {
+
+    if (!getPreference(@"button_scale")) {
+        setPreference(@"button_scale", @(100));
+    }
+
+    if (!getPreference(@"selected_version")) {
+        setPreference(@"selected_version", @"1.7.10");
+    }
+
+    if (!getPreference(@"vertype_release")) {
+        setPreference(@"vertype_release", @YES);
+    }
+
+    if (!getPreference(@"vertype_snapshot")) {
+        setPreference(@"vertype_snapshot", @NO);
+    }
+
+    if (!getPreference(@"vertype_oldalpha")) {
+        setPreference(@"vertype_oldalpha", @NO);
+    }
+
+    if (!getPreference(@"vertype_oldbeta")) {
+        setPreference(@"vertype_oldbeta", @NO);
+    }
+
+    if (!getPreference(@"time_longPressTrigger")) {
+        setPreference(@"time_longPressTrigger", @(400));
+    }
+
+    if (!getPreference(@"default_ctrl")) {
+        setPreference(@"default_ctrl", @"default.json");
+    }
+
+    if (!getPreference(@"java_args")) {
+        setPreference(@"java_args", @"");
+    }
+
+    if (!getPreference(@"java_home")) {
+        setPreference(@"java_home", @"");
+    }
+
+    if (!getPreference(@"gl4es_libname")) {
+        setPreference(@"gl4es_libname", @"");
+    }
+
+    if (!getPreference(@"option_warn")) {
+        setPreference(@"option_warn", @YES);
+    }
+
+    if (!getPreference(@"local_warn")) {
+        setPreference(@"local_warn", @YES);
+    }
+}
 
 int launchJVM(int argc, char *argv[]) {
     char *homeDir;
@@ -112,6 +166,8 @@ int launchJVM(int argc, char *argv[]) {
     } else {
         homeDir = getenv("POJAV_HOME");
     }
+
+    init_checkPlist();
 
     loadPreferences();
     init_migrateToPlist("selected_version", "config_ver.txt");

--- a/Natives/JavaLauncher.m
+++ b/Natives/JavaLauncher.m
@@ -59,9 +59,9 @@ static int pfd[2];
 static pthread_t logger;
 
 const char *javaHome;
-const char *gl4esLibname;
+const char *renderer;
 NSString *javaHome_pre;
-NSString *gl4esLibname_pre;
+NSString *renderer_pre;
 
 void init_loadCustomJvmFlags() {
     NSString *jvmargs = getPreference(@"java_args");
@@ -135,8 +135,8 @@ void init_checkPlist() {
         setPreference(@"java_home", @"");
     }
 
-    if (!getPreference(@"gl4es_libname")) {
-        setPreference(@"gl4es_libname", @"");
+    if (!getPreference(@"renderer")) {
+        setPreference(@"renderer", @"");
     }
 
     if (!getPreference(@"option_warn")) {
@@ -248,23 +248,23 @@ int launchJVM(int argc, char *argv[]) {
         }
     }
 
-    gl4esLibname_pre = getPreference(@"gl4es_libname");
-    gl4esLibname = [gl4esLibname_pre cStringUsingEncoding:NSUTF8StringEncoding];
-    if ([gl4esLibname_pre length] == 0) {
-        gl4esLibname_pre = @"libgl4es_114.dylib";
-        setPreference(@"gl4es_libname", gl4esLibname_pre);
-        gl4esLibname = [gl4esLibname_pre cStringUsingEncoding:NSUTF8StringEncoding];
-        setenv("GL4ES_LIBNAME", gl4esLibname, 1);
-        debug("[Pre-init] GL4ES_LIBNAME environment variable was not set. Defaulting to %s for future use.\n", gl4esLibname);
+    renderer_pre = getPreference(@"renderer");
+    renderer = [renderer_pre cStringUsingEncoding:NSUTF8StringEncoding];
+    if ([renderer_pre length] == 0) {
+        renderer_pre = @"libgl4es_114.dylib";
+        setPreference(@"renderer", renderer_pre);
+        renderer = [renderer_pre cStringUsingEncoding:NSUTF8StringEncoding];
+        setenv("RENDERER", renderer, 1);
+        debug("[Pre-init] RENDERER environment variable was not set. Defaulting to %s for future use.\n", renderer);
     } else {
-        if(![gl4esLibname_pre isEqualToString:@"libgl4es_114.dylib"] && ![gl4esLibname_pre isEqualToString:@"libgl4es_115.dylib"]) {
-            debug("[Pre-Init] Failed to locate %s. Restoring default value for GL4ES_LIBNAME.", gl4esLibname);
-            gl4esLibname_pre = @"libgl4es_114.dylib";
-            setPreference(@"gl4es_libname", gl4esLibname_pre);
-            gl4esLibname = [gl4esLibname_pre cStringUsingEncoding:NSUTF8StringEncoding];
-            setenv("GL4ES_LIBNAME", gl4esLibname, 1);
+        if(![renderer_pre isEqualToString:@"libgl4es_114.dylib"] && ![renderer_pre isEqualToString:@"libgl4es_115.dylib"]) {
+            debug("[Pre-Init] Failed to locate %s. Restoring default value for RENDERER.", renderer);
+            renderer_pre = @"libgl4es_114.dylib";
+            setPreference(@"renderer", renderer_pre);
+            renderer = [renderer_pre cStringUsingEncoding:NSUTF8StringEncoding];
+            setenv("RENDERER", renderer, 1);
         } else {
-            debug("[Pre-Init] Restored preference: GL4ES_LIBNAME is set to %s\n", gl4esLibname);
+            debug("[Pre-Init] Restored preference: RENDERER is set to %s\n", renderer);
         }
     }
 
@@ -296,14 +296,14 @@ int launchJVM(int argc, char *argv[]) {
     if (!started) {
         char *frameworkPath = calloc(1, 2048);
         char *javaPath = calloc(1, 2048);
-        char *gl4esPath = calloc(1, 2048);
+        char *rendererPath = calloc(1, 2048);
         char *userDir = calloc(1, 2048);
         char *userHome = calloc(1, 2048);
         snprintf(frameworkPath, 2048, "-Djava.library.path=%s/Frameworks", getenv("BUNDLE_PATH"));
         snprintf(javaPath, 2048, "%s/bin/java", javaHome);
         snprintf(userDir, 2048, "-Duser.dir=%s/Documents/minecraft", getenv("HOME"));
         snprintf(userHome, 2048, "-Duser.home=%s/Documents", getenv("HOME"));
-        snprintf(gl4esPath, 2048, "-Dorg.lwjgl.opengl.libname=%s", gl4esLibname);
+        snprintf(rendererPath, 2048, "-Dorg.lwjgl.opengl.libname=%s", renderer);
         
         chdir(userDir);
         
@@ -313,11 +313,11 @@ int launchJVM(int argc, char *argv[]) {
         margv[margc++] = frameworkPath;
         margv[margc++] = userDir;
         margv[margc++] = userHome;
-        margv[margc++] = gl4esPath;
+        margv[margc++] = rendererPath;
         margv[margc++] = "-Dorg.lwjgl.system.allocator=system";
     } else {
-        setenv("GL4ES_LIBNAME", gl4esLibname, 1);
-        debug("[Pre-init] GL4ES_LIBNAME has been set to %s", getenv("GL4ES_LIBNAME"));
+        setenv("RENDERER", renderer, 1);
+        debug("[Pre-init] GL4ES_LIBNAME has been set to %s", getenv("RENDERER"));
     }
 
     // Load java

--- a/Natives/JavaLauncher.m
+++ b/Natives/JavaLauncher.m
@@ -211,6 +211,7 @@ int launchJVM(int argc, char *argv[]) {
     setenv("LIBGL_NORMALIZE", "1", 1);
 
     javaHome_pre = getPreference(@"java_home");
+    javaHome = [javaHome_pre cStringUsingEncoding:NSUTF8StringEncoding];
     if ([javaHome_pre length] == 0) {
         if (strncmp(argv[0], "/Applications", 13) == 0) {
             if (0 != access("/usr/lib/jvm/java-8-openjdk/", F_OK)) {
@@ -243,12 +244,12 @@ int launchJVM(int argc, char *argv[]) {
                 setPreference(@"java_home", javaHome_pre);
             }
         } else {
-            javaHome = [javaHome_pre cStringUsingEncoding:NSUTF8StringEncoding];
             debug("[Pre-Init] Restored preference: JAVA_HOME is set to %s\n", javaHome);
         }
     }
 
     gl4esLibname_pre = getPreference(@"gl4es_libname");
+    gl4esLibname = [gl4esLibname_pre cStringUsingEncoding:NSUTF8StringEncoding];
     if ([gl4esLibname_pre length] == 0) {
         gl4esLibname_pre = @"libgl4es_114.dylib";
         setPreference(@"gl4es_libname", gl4esLibname_pre);
@@ -256,8 +257,15 @@ int launchJVM(int argc, char *argv[]) {
         setenv("GL4ES_LIBNAME", gl4esLibname, 1);
         debug("[Pre-init] GL4ES_LIBNAME environment variable was not set. Defaulting to %s for future use.\n", gl4esLibname);
     } else {
-        gl4esLibname = [gl4esLibname_pre cStringUsingEncoding:NSUTF8StringEncoding];
-        debug("[Pre-Init] Restored preference: GL4ES_LIBNAME is set to %s\n", gl4esLibname);
+        if(![gl4esLibname_pre isEqualToString:@"libgl4es_114.dylib"] && ![gl4esLibname_pre isEqualToString:@"libgl4es_115.dylib"]) {
+            debug("[Pre-Init] Failed to locate %s. Restoring default value for GL4ES_LIBNAME.", gl4esLibname);
+            gl4esLibname_pre = @"libgl4es_114.dylib";
+            setPreference(@"gl4es_libname", gl4esLibname_pre);
+            gl4esLibname = [gl4esLibname_pre cStringUsingEncoding:NSUTF8StringEncoding];
+            setenv("GL4ES_LIBNAME", gl4esLibname, 1);
+        } else {
+            debug("[Pre-Init] Restored preference: GL4ES_LIBNAME is set to %s\n", gl4esLibname);
+        }
     }
 
     char controlPath[2048];

--- a/Natives/JavaLauncher.m
+++ b/Natives/JavaLauncher.m
@@ -187,6 +187,7 @@ int launchJVM(int argc, char *argv[]) {
                 setPreference(@"java_home", javaHome_pre);
             }
         } else {
+            javaHome = [javaHome_pre cStringUsingEncoding:NSUTF8StringEncoding];
             debug("[Pre-Init] Restored preference: JAVA_HOME is set to %s\n", javaHome);
         }
     }

--- a/Natives/LauncherPreferences.m
+++ b/Natives/LauncherPreferences.m
@@ -19,6 +19,8 @@ void loadPreferences() {
         prefDict[@"time_longPressTrigger"] = @(400);
         prefDict[@"default_ctrl"] = @"default.json";
         prefDict[@"java_args"] = @"";
+        prefDict[@"java_home"] = @"";
+        prefDict[@"gl4es_libname"] = @"";
         // prefDict[@"custom_envVars"] = @""; // TODO
         [prefDict writeToFile:prefPath atomically:YES];
     } else {

--- a/Natives/LauncherPreferences.m
+++ b/Natives/LauncherPreferences.m
@@ -20,7 +20,7 @@ void loadPreferences() {
         prefDict[@"default_ctrl"] = @"default.json";
         prefDict[@"java_args"] = @"";
         prefDict[@"java_home"] = @"";
-        prefDict[@"gl4es_libname"] = @"";
+        prefDict[@"renderer"] = @"";
         prefDict[@"option_warn"] = @YES;
         prefDict[@"local_warn"] = @YES;
         [prefDict writeToFile:prefPath atomically:YES];

--- a/Natives/LauncherPreferences.m
+++ b/Natives/LauncherPreferences.m
@@ -21,7 +21,8 @@ void loadPreferences() {
         prefDict[@"java_args"] = @"";
         prefDict[@"java_home"] = @"";
         prefDict[@"gl4es_libname"] = @"";
-        // prefDict[@"custom_envVars"] = @""; // TODO
+        prefDict[@"option_warn"] = @YES;
+        prefDict[@"local_warn"] = @YES;
         [prefDict writeToFile:prefPath atomically:YES];
     } else {
         prefDict = [NSMutableDictionary dictionaryWithContentsOfFile:prefPath];

--- a/Natives/LauncherPreferencesViewController.h
+++ b/Natives/LauncherPreferencesViewController.h
@@ -1,6 +1,6 @@
 #import <UIKit/UIKit.h>
 
-@interface LauncherPreferencesViewController : UIViewController
+@interface LauncherPreferencesViewController : UIViewController <UITextFieldDelegate>
 
 @end
 

--- a/Natives/LauncherPreferencesViewController.m
+++ b/Natives/LauncherPreferencesViewController.m
@@ -6,7 +6,7 @@
 
 #define BTNSCALE 0
 #define JARGS 1
-#define GL4ES 2
+#define REND 2
 #define JHOME 3
 
 @interface LauncherPreferencesViewController () {
@@ -18,7 +18,7 @@
 
 @implementation LauncherPreferencesViewController
 
-UITextField* gl4esTextField;
+UITextField* rendTextField;
 UITextField* jargsTextField;
 UITextField* jhomeTextField;
 UITextField* versionTextField;
@@ -82,21 +82,21 @@ UITextField* versionTextField;
     jargsTextField.contentHorizontalAlignment = UIControlContentHorizontalAlignmentLeft;
     [scrollView addSubview:jargsTextField];
 
-    UILabel *gl4esTextView = [[UILabel alloc] initWithFrame:CGRectMake(4.0, 94.0, 0.0, 0.0)];
-    gl4esTextView.text = @"GL4ES dylib";
-    gl4esTextView.numberOfLines = 0;
-    [gl4esTextView sizeToFit];
-    [scrollView addSubview:gl4esTextView];
+    UILabel *rendTextView = [[UILabel alloc] initWithFrame:CGRectMake(4.0, 94.0, 0.0, 0.0)];
+    rendTextView.text = @"Renderer";
+    rendTextView.numberOfLines = 0;
+    [rendTextView sizeToFit];
+    [scrollView addSubview:rendTextView];
 
-    gl4esTextField = [[UITextField alloc] initWithFrame:CGRectMake(buttonSizeSlider.frame.origin.x + 3, 94.0, width - jargsTextView.bounds.size.width - 8.0, 30)];
-    [gl4esTextField addTarget:versionTextField action:@selector(resignFirstResponder) forControlEvents:UIControlEventEditingDidEndOnExit];
-    gl4esTextField.tag = 101;
-    gl4esTextField.delegate = self;
-    gl4esTextField.placeholder = @"Override version...";
-    gl4esTextField.text = (NSString *) getPreference(@"gl4es_libname");
-    gl4esTextField.contentVerticalAlignment = UIControlContentVerticalAlignmentTop;
-    gl4esTextField.contentHorizontalAlignment = UIControlContentHorizontalAlignmentLeft;
-    [scrollView addSubview:gl4esTextField];
+    rendTextField = [[UITextField alloc] initWithFrame:CGRectMake(buttonSizeSlider.frame.origin.x + 3, 94.0, width - jargsTextView.bounds.size.width - 8.0, 30)];
+    [rendTextField addTarget:versionTextField action:@selector(resignFirstResponder) forControlEvents:UIControlEventEditingDidEndOnExit];
+    rendTextField.tag = 101;
+    rendTextField.delegate = self;
+    rendTextField.placeholder = @"Override renderer...";
+    rendTextField.text = (NSString *) getPreference(@"renderer");
+    rendTextField.contentVerticalAlignment = UIControlContentVerticalAlignmentTop;
+    rendTextField.contentHorizontalAlignment = UIControlContentHorizontalAlignmentLeft;
+    [scrollView addSubview:rendTextField];
 
     UILabel *jhomeTextView = [[UILabel alloc] initWithFrame:CGRectMake(4.0, 134.0, 0.0, 0.0)];
     jhomeTextView.text = @"Java home";
@@ -129,8 +129,8 @@ UITextField* versionTextField;
                              handler:^(__kindof UIAction * _Nonnull action) {[self helpAlertOpt:BTNSCALE];}];
         UIAction *option2 = [UIAction actionWithTitle:@"Java arguments" image:nil identifier:nil
                              handler:^(__kindof UIAction * _Nonnull action) {[self helpAlertOpt:JARGS];}];
-        UIAction *option3 = [UIAction actionWithTitle:@"GL4ES dylib" image:nil identifier:nil
-                             handler:^(__kindof UIAction * _Nonnull action) {[self helpAlertOpt:GL4ES];}];
+        UIAction *option3 = [UIAction actionWithTitle:@"Renderer" image:nil identifier:nil
+                             handler:^(__kindof UIAction * _Nonnull action) {[self helpAlertOpt:REND];}];
         UIAction *option4 = [UIAction actionWithTitle:@"Java home" image:nil identifier:nil
                              handler:^(__kindof UIAction * _Nonnull action) {[self helpAlertOpt:JHOME];}];
         UIMenu *menu = [UIMenu menuWithTitle:@"Help menu" image:nil identifier:nil
@@ -148,7 +148,7 @@ UITextField* versionTextField;
     if (textField.tag == 100) {
         setPreference(@"java_args", jargsTextField.text);
     } else if (textField.tag == 101) {
-        setPreference(@"gl4es_libname", gl4esTextField.text);
+        setPreference(@"renderer", rendTextField.text);
     } else if (textField.tag == 102) {
         setPreference(@"java_home", jhomeTextField.text);
         if (![jhomeTextField.text containsString:@"java-8-openjdk"]) {
@@ -167,13 +167,13 @@ UITextField* versionTextField;
         UIAlertController *helpAlert = [UIAlertController alertControllerWithTitle:@"Needing help with these preferences?" message:nil preferredStyle:UIAlertControllerStyleActionSheet];
         UIAlertAction *btnscale = [UIAlertAction actionWithTitle:@"Button scale" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {[self helpAlertOpt:BTNSCALE];}];
         UIAlertAction *jargs = [UIAlertAction actionWithTitle:@"Java arguments" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {[self helpAlertOpt:JARGS];}];
-        UIAlertAction *gl4eslib = [UIAlertAction actionWithTitle:@"GL4ES dylib"  style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {[self helpAlertOpt:GL4ES];}];
+        UIAlertAction *renderer = [UIAlertAction actionWithTitle:@"rend dylib"  style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {[self helpAlertOpt:REND];}];
         UIAlertAction *jhome = [UIAlertAction actionWithTitle:@"Java home" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {[self helpAlertOpt:JHOME];}];
         UIAlertAction *cancel = [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil];
         [self presentViewController:helpAlert animated:YES completion:nil];
         [helpAlert addAction:btnscale];
         [helpAlert addAction:jargs];
-        [helpAlert addAction:gl4eslib];
+        [helpAlert addAction:renderer];
         [helpAlert addAction:jhome];
         [helpAlert addAction:cancel];
     }
@@ -188,9 +188,9 @@ UITextField* versionTextField;
     } else if(setting == JARGS) {
         title = @"Java arguments";
         message = @"This option allows you to edit arguments that can be passed to Minecraft. Not all arguments work with PojavLauncher, so be aware. This option also requires a restart of the launcher to take effect.";
-    } else if(setting == GL4ES) {
-        title = @"GL4ES dylib";
-        message = @"This option allows you to change the gl4es version in use. Typing 'libgl4es_115.dylib' may fix sheep and banner colors on 1.16 and allow 1.17 to be played, but will also not work with older versions. This option also requires a restart of the launcher to take effect.";
+    } else if(setting == REND) {
+        title = @"Renderer";
+        message = @"This option allows you to change the renderer in use. Typing 'libgl4es_115.dylib' may fix sheep and banner colors on 1.16 and allow 1.17 to be played, but will also not work with older versions. This option also requires a restart of the launcher to take effect.";
     } else if(setting == JHOME) {
         title = @"Java home";
         message = @"This option allows you to change the Java executable directory. Typing '/usr/lib/jvm/java-16-openjdk' may allow you to play 1.17, however older versions and most versions of modded Minecraft, as well as the mod installer, will not work. This option also requires a restart of the launcher to take effect.";

--- a/Natives/LauncherPreferencesViewController.m
+++ b/Natives/LauncherPreferencesViewController.m
@@ -13,7 +13,9 @@
 
 @implementation LauncherPreferencesViewController
 
+UITextField* gl4esTextField;
 UITextField* jargsTextField;
+UITextField* jhomeTextField;
 UITextField* versionTextField;
 
 - (void)viewDidLoad
@@ -66,7 +68,7 @@ UITextField* versionTextField;
     [jargsTextView sizeToFit];
     [scrollView addSubview:jargsTextView];
 
-    jargsTextField = [[UITextField alloc] initWithFrame:CGRectMake(jargsTextView.bounds.size.width + 4.0, 54.0, width - jargsTextView.bounds.size.width - 8.0, height - 58.0)];
+    jargsTextField = [[UITextField alloc] initWithFrame:CGRectMake(buttonSizeSlider.frame.origin.x, 54.0, width - jargsTextView.bounds.size.width - 8.0, height - 58.0)];
     [jargsTextField addTarget:versionTextField action:@selector(resignFirstResponder) forControlEvents:UIControlEventEditingDidEndOnExit];
     jargsTextField.tag = 100;
     jargsTextField.delegate = self;
@@ -76,6 +78,47 @@ UITextField* versionTextField;
     jargsTextField.contentHorizontalAlignment = UIControlContentHorizontalAlignmentLeft;
     [scrollView addSubview:jargsTextField];
 
+    UILabel *gl4esTextView = [[UILabel alloc] initWithFrame:CGRectMake(4.0, 94.0, 0.0, 0.0)];
+    gl4esTextView.text = @"GL4ES dylib";
+    gl4esTextView.numberOfLines = 0;
+    [gl4esTextView sizeToFit];
+    [scrollView addSubview:gl4esTextView];
+
+    gl4esTextField = [[UITextField alloc] initWithFrame:CGRectMake(buttonSizeSlider.frame.origin.x, 94.0, width - jargsTextView.bounds.size.width - 8.0, height - 58.0)];
+    [gl4esTextField addTarget:versionTextField action:@selector(resignFirstResponder) forControlEvents:UIControlEventEditingDidEndOnExit];
+    gl4esTextField.tag = 101;
+    gl4esTextField.delegate = self;
+    gl4esTextField.placeholder = @"Override version...";
+    gl4esTextField.text = (NSString *) getPreference(@"gl4es_libname");
+    gl4esTextField.contentVerticalAlignment = UIControlContentVerticalAlignmentTop;
+    gl4esTextField.contentHorizontalAlignment = UIControlContentHorizontalAlignmentLeft;
+    [scrollView addSubview:gl4esTextField];
+
+    UILabel *jhomeTextView = [[UILabel alloc] initWithFrame:CGRectMake(4.0, 134.0, 0.0, 0.0)];
+    jhomeTextView.text = @"Java home";
+    jhomeTextView.numberOfLines = 0;
+    [jhomeTextView sizeToFit];
+    [scrollView addSubview:jhomeTextView];
+
+    jhomeTextField = [[UITextField alloc] initWithFrame:CGRectMake(buttonSizeSlider.frame.origin.x, 134.0, width - jargsTextView.bounds.size.width - 8.0, height - 58.0)];
+    [jhomeTextField addTarget:versionTextField action:@selector(resignFirstResponder) forControlEvents:UIControlEventEditingDidEndOnExit];
+    jhomeTextField.tag = 102;
+    jhomeTextField.delegate = self;
+    jhomeTextField.placeholder = @"Override Java path...";
+    jhomeTextField.text = (NSString *) getPreference(@"java_home");
+    jhomeTextField.contentVerticalAlignment = UIControlContentVerticalAlignmentTop;
+    jhomeTextField.contentHorizontalAlignment = UIControlContentHorizontalAlignmentLeft;
+    [scrollView addSubview:jhomeTextField];
+
+    if (getPreference(@"opt_warn") == @"true") {
+
+    } else {
+        UIAlertController *fullAlert = [UIAlertController alertControllerWithTitle:@"Requirement for modifying settings" message:@"Changing Java arguments requires a restart of the launcher to take effect."preferredStyle:UIAlertControllerStyleAlert];
+        UIAlertAction *ok = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleCancel handler:nil];
+        [self presentViewController:fullAlert animated:YES completion:nil];
+        [fullAlert addAction:ok];
+        setPreference(@"opt_warn", @"true");
+    }
     scrollView.contentSize = CGSizeMake(scrollView.frame.size.width, scrollView.frame.size.height + 200);
 }
 
@@ -83,10 +126,10 @@ UITextField* versionTextField;
 {
     if (textField.tag == 100) {
         setPreference(@"java_args", jargsTextField.text);
-        UIAlertController *fullAlert = [UIAlertController alertControllerWithTitle:@"Restart the launcher" message:@"Changing Java arguments requires a restart of the launcher to take effect."preferredStyle:UIAlertControllerStyleAlert];
-        UIAlertAction *ok = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleCancel handler:nil];
-        [self presentViewController:fullAlert animated:YES completion:nil];
-        [fullAlert addAction:ok];
+    } else if (textField.tag == 101) {
+        setPreference(@"gl4es_libname", gl4esTextField.text);
+    } else if (textField.tag == 102) {
+        setPreference(@"java_home", jhomeTextField.text);
     }
 }
 

--- a/Natives/LauncherPreferencesViewController.m
+++ b/Natives/LauncherPreferencesViewController.m
@@ -110,15 +110,6 @@ UITextField* versionTextField;
     jhomeTextField.contentHorizontalAlignment = UIControlContentHorizontalAlignmentLeft;
     [scrollView addSubview:jhomeTextField];
 
-    if (getPreference(@"opt_warn") == @"true") {
-
-    } else {
-        UIAlertController *fullAlert = [UIAlertController alertControllerWithTitle:@"Requirement for modifying settings" message:@"Changing Java arguments requires a restart of the launcher to take effect."preferredStyle:UIAlertControllerStyleAlert];
-        UIAlertAction *ok = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleCancel handler:nil];
-        [self presentViewController:fullAlert animated:YES completion:nil];
-        [fullAlert addAction:ok];
-        setPreference(@"opt_warn", @"true");
-    }
     scrollView.contentSize = CGSizeMake(scrollView.frame.size.width, scrollView.frame.size.height + 200);
 }
 

--- a/Natives/LauncherPreferencesViewController.m
+++ b/Natives/LauncherPreferencesViewController.m
@@ -110,6 +110,14 @@ UITextField* versionTextField;
     jhomeTextField.contentHorizontalAlignment = UIControlContentHorizontalAlignmentLeft;
     [scrollView addSubview:jhomeTextField];
 
+    if ([getPreference(@"option_warn") boolValue] == YES) {
+        UIAlertController *fullAlert = [UIAlertController alertControllerWithTitle:@"Restart required" message:@"Some options in this menu will require that you restart the launcher for them to take effect."preferredStyle:UIAlertControllerStyleAlert];
+        UIAlertAction *cancel = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleCancel handler:nil];
+        [self presentViewController:fullAlert animated:YES completion:nil];
+        [fullAlert addAction:cancel];
+        setPreference(@"option_warn", @NO);
+    }
+
     scrollView.contentSize = CGSizeMake(scrollView.frame.size.width, scrollView.frame.size.height + 200);
 }
 

--- a/Natives/LauncherPreferencesViewController.m
+++ b/Natives/LauncherPreferencesViewController.m
@@ -111,10 +111,10 @@ UITextField* versionTextField;
     [scrollView addSubview:jhomeTextField];
 
     if ([getPreference(@"option_warn") boolValue] == YES) {
-        UIAlertController *fullAlert = [UIAlertController alertControllerWithTitle:@"Restart required" message:@"Some options in this menu will require that you restart the launcher for them to take effect."preferredStyle:UIAlertControllerStyleAlert];
-        UIAlertAction *cancel = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleCancel handler:nil];
-        [self presentViewController:fullAlert animated:YES completion:nil];
-        [fullAlert addAction:cancel];
+        UIAlertController *preferenceWarn = [UIAlertController alertControllerWithTitle:@"Restart required" message:@"Some options in this menu will require that you restart the launcher for them to take effect."preferredStyle:UIAlertControllerStyleAlert];
+        UIAlertAction *ok = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleCancel handler:nil];
+        [self presentViewController:preferenceWarn animated:YES completion:nil];
+        [preferenceWarn addAction:ok];
         setPreference(@"option_warn", @NO);
     }
 
@@ -129,6 +129,12 @@ UITextField* versionTextField;
         setPreference(@"gl4es_libname", gl4esTextField.text);
     } else if (textField.tag == 102) {
         setPreference(@"java_home", jhomeTextField.text);
+        if (![jhomeTextField.text containsString:@"java-8-openjdk"]) {
+            UIAlertController *javaAlert = [UIAlertController alertControllerWithTitle:@"Java version is not Java 8" message:@"Minecraft versions below 1.6, modded below 1.16.4, and the mod installer will not work unless you have Java 8 installed on your device."preferredStyle:UIAlertControllerStyleAlert];
+            UIAlertAction *ok = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleCancel handler:nil];
+            [self presentViewController:javaAlert animated:YES completion:nil];
+            [javaAlert addAction:ok];
+        }
     }
 }
 

--- a/Natives/LauncherPreferencesViewController.m
+++ b/Natives/LauncherPreferencesViewController.m
@@ -4,6 +4,11 @@
 
 #include "utils.h"
 
+#define BTNSCALE 0
+#define JARGS 1
+#define GL4ES 2
+#define JHOME 3
+
 @interface LauncherPreferencesViewController () {
 }
 
@@ -49,7 +54,6 @@ UITextField* versionTextField;
     CGRect tempRect = btnsizeTextView.frame;
     tempRect.size.height = 30.0;
     btnsizeTextView.frame = tempRect;
-    
     [scrollView addSubview:btnsizeTextView];
     
     DBNumberedSlider *buttonSizeSlider = [[DBNumberedSlider alloc] initWithFrame:CGRectMake(8.0 + btnsizeTextView.frame.size.width, 8.0, self.view.frame.size.width - btnsizeTextView.frame.size.width - 12.0, btnsizeTextView.frame.size.height)];
@@ -68,7 +72,7 @@ UITextField* versionTextField;
     [jargsTextView sizeToFit];
     [scrollView addSubview:jargsTextView];
 
-    jargsTextField = [[UITextField alloc] initWithFrame:CGRectMake(buttonSizeSlider.frame.origin.x, 54.0, width - jargsTextView.bounds.size.width - 8.0, 30)];
+    jargsTextField = [[UITextField alloc] initWithFrame:CGRectMake(buttonSizeSlider.frame.origin.x + 3, 54.0, width - jargsTextView.bounds.size.width - 8.0, 30)];
     [jargsTextField addTarget:versionTextField action:@selector(resignFirstResponder) forControlEvents:UIControlEventEditingDidEndOnExit];
     jargsTextField.tag = 100;
     jargsTextField.delegate = self;
@@ -84,7 +88,7 @@ UITextField* versionTextField;
     [gl4esTextView sizeToFit];
     [scrollView addSubview:gl4esTextView];
 
-    gl4esTextField = [[UITextField alloc] initWithFrame:CGRectMake(buttonSizeSlider.frame.origin.x, 94.0, width - jargsTextView.bounds.size.width - 8.0, 30)];
+    gl4esTextField = [[UITextField alloc] initWithFrame:CGRectMake(buttonSizeSlider.frame.origin.x + 3, 94.0, width - jargsTextView.bounds.size.width - 8.0, 30)];
     [gl4esTextField addTarget:versionTextField action:@selector(resignFirstResponder) forControlEvents:UIControlEventEditingDidEndOnExit];
     gl4esTextField.tag = 101;
     gl4esTextField.delegate = self;
@@ -100,7 +104,7 @@ UITextField* versionTextField;
     [jhomeTextView sizeToFit];
     [scrollView addSubview:jhomeTextView];
 
-    jhomeTextField = [[UITextField alloc] initWithFrame:CGRectMake(buttonSizeSlider.frame.origin.x, 134.0, width - jargsTextView.bounds.size.width - 8.0, 30)];
+    jhomeTextField = [[UITextField alloc] initWithFrame:CGRectMake(buttonSizeSlider.frame.origin.x + 3, 134.0, width - jargsTextView.bounds.size.width - 8.0, 30)];
     [jhomeTextField addTarget:versionTextField action:@selector(resignFirstResponder) forControlEvents:UIControlEventEditingDidEndOnExit];
     jhomeTextField.tag = 102;
     jhomeTextField.delegate = self;
@@ -116,6 +120,24 @@ UITextField* versionTextField;
         [self presentViewController:preferenceWarn animated:YES completion:nil];
         [preferenceWarn addAction:ok];
         setPreference(@"option_warn", @NO);
+    }
+
+    self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"?" style:UIBarButtonItemStyleDone target:self action:@selector(helpMenu)];
+    if (@available(iOS 14.0, *)) {
+        // use UIMenu
+        UIAction *option1 = [UIAction actionWithTitle:@"Button scale" image:nil identifier:nil
+                             handler:^(__kindof UIAction * _Nonnull action) {[self helpAlertOpt:BTNSCALE];}];
+        UIAction *option2 = [UIAction actionWithTitle:@"Java arguments" image:nil identifier:nil
+                             handler:^(__kindof UIAction * _Nonnull action) {[self helpAlertOpt:JARGS];}];
+        UIAction *option3 = [UIAction actionWithTitle:@"GL4ES dylib" image:nil identifier:nil
+                             handler:^(__kindof UIAction * _Nonnull action) {[self helpAlertOpt:GL4ES];}];
+        UIAction *option4 = [UIAction actionWithTitle:@"Java home" image:nil identifier:nil
+                             handler:^(__kindof UIAction * _Nonnull action) {[self helpAlertOpt:JHOME];}];
+        UIMenu *menu = [UIMenu menuWithTitle:@"Help menu" image:nil identifier:nil
+                        options:UIMenuOptionsDisplayInline children:@[option1, option2, option3, option4]];
+        self.navigationItem.rightBarButtonItem.action = nil;
+        self.navigationItem.rightBarButtonItem.primaryAction = nil;
+        self.navigationItem.rightBarButtonItem.menu = menu;
     }
 
     scrollView.contentSize = CGSizeMake(scrollView.frame.size.width, scrollView.frame.size.height + 200);
@@ -138,6 +160,46 @@ UITextField* versionTextField;
     }
 }
 
+- (void)helpMenu {
+    if (@available(iOS 14.0, *)) {
+        // UIMenu
+    } else {
+        UIAlertController *helpAlert = [UIAlertController alertControllerWithTitle:@"Needing help with these preferences?" message:nil preferredStyle:UIAlertControllerStyleActionSheet];
+        UIAlertAction *btnscale = [UIAlertAction actionWithTitle:@"Button scale" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {[self helpAlertOpt:BTNSCALE];}];
+        UIAlertAction *jargs = [UIAlertAction actionWithTitle:@"Java arguments" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {[self helpAlertOpt:JARGS];}];
+        UIAlertAction *gl4eslib = [UIAlertAction actionWithTitle:@"GL4ES dylib"  style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {[self helpAlertOpt:GL4ES];}];
+        UIAlertAction *jhome = [UIAlertAction actionWithTitle:@"Java home" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {[self helpAlertOpt:JHOME];}];
+        UIAlertAction *cancel = [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil];
+        [self presentViewController:helpAlert animated:YES completion:nil];
+        [helpAlert addAction:btnscale];
+        [helpAlert addAction:jargs];
+        [helpAlert addAction:gl4eslib];
+        [helpAlert addAction:jhome];
+        [helpAlert addAction:cancel];
+    }
+}
+
+- (void)helpAlertOpt:(int)setting {
+    NSString *title;
+    NSString *message;
+    if(setting == BTNSCALE) {
+        title = @"Button scale";
+        message = @"This option allows you to tweak the button scale of the on-screen controls. The numbered slider extends from 50 to 500.";
+    } else if(setting == JARGS) {
+        title = @"Java arguments";
+        message = @"This option allows you to edit arguments that can be passed to Minecraft. Not all arguments work with PojavLauncher, so be aware. This option also requires a restart of the launcher to take effect.";
+    } else if(setting == GL4ES) {
+        title = @"GL4ES dylib";
+        message = @"This option allows you to change the gl4es version in use. Typing 'libgl4es_115.dylib' may fix sheep and banner colors on 1.16 and allow 1.17 to be played, but will also not work with older versions. This option also requires a restart of the launcher to take effect.";
+    } else if(setting == JHOME) {
+        title = @"Java home";
+        message = @"This option allows you to change the Java executable directory. Typing '/usr/lib/jvm/java-16-openjdk' may allow you to play 1.17, however older versions and most versions of modded Minecraft, as well as the mod installer, will not work. This option also requires a restart of the launcher to take effect.";
+    }
+    UIAlertController *helpAlertOpt = [UIAlertController alertControllerWithTitle:title message:message preferredStyle:UIAlertControllerStyleActionSheet];
+    UIAlertAction *ok = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleCancel handler:nil];
+    [helpAlertOpt addAction:ok];
+    [self presentViewController:helpAlertOpt animated:YES completion:nil];
+}
 
 - (void)sliderMoved:(DBNumberedSlider *)sender {
     switch (sender.tag) {

--- a/Natives/LauncherPreferencesViewController.m
+++ b/Natives/LauncherPreferencesViewController.m
@@ -68,7 +68,7 @@ UITextField* versionTextField;
     [jargsTextView sizeToFit];
     [scrollView addSubview:jargsTextView];
 
-    jargsTextField = [[UITextField alloc] initWithFrame:CGRectMake(buttonSizeSlider.frame.origin.x, 54.0, width - jargsTextView.bounds.size.width - 8.0, height - 58.0)];
+    jargsTextField = [[UITextField alloc] initWithFrame:CGRectMake(buttonSizeSlider.frame.origin.x, 54.0, width - jargsTextView.bounds.size.width - 8.0, 30)];
     [jargsTextField addTarget:versionTextField action:@selector(resignFirstResponder) forControlEvents:UIControlEventEditingDidEndOnExit];
     jargsTextField.tag = 100;
     jargsTextField.delegate = self;
@@ -84,7 +84,7 @@ UITextField* versionTextField;
     [gl4esTextView sizeToFit];
     [scrollView addSubview:gl4esTextView];
 
-    gl4esTextField = [[UITextField alloc] initWithFrame:CGRectMake(buttonSizeSlider.frame.origin.x, 94.0, width - jargsTextView.bounds.size.width - 8.0, height - 58.0)];
+    gl4esTextField = [[UITextField alloc] initWithFrame:CGRectMake(buttonSizeSlider.frame.origin.x, 94.0, width - jargsTextView.bounds.size.width - 8.0, 30)];
     [gl4esTextField addTarget:versionTextField action:@selector(resignFirstResponder) forControlEvents:UIControlEventEditingDidEndOnExit];
     gl4esTextField.tag = 101;
     gl4esTextField.delegate = self;
@@ -100,7 +100,7 @@ UITextField* versionTextField;
     [jhomeTextView sizeToFit];
     [scrollView addSubview:jhomeTextView];
 
-    jhomeTextField = [[UITextField alloc] initWithFrame:CGRectMake(buttonSizeSlider.frame.origin.x, 134.0, width - jargsTextView.bounds.size.width - 8.0, height - 58.0)];
+    jhomeTextField = [[UITextField alloc] initWithFrame:CGRectMake(buttonSizeSlider.frame.origin.x, 134.0, width - jargsTextView.bounds.size.width - 8.0, 30)];
     [jhomeTextField addTarget:versionTextField action:@selector(resignFirstResponder) forControlEvents:UIControlEventEditingDidEndOnExit];
     jhomeTextField.tag = 102;
     jhomeTextField.delegate = self;

--- a/Natives/LoginViewController.m
+++ b/Natives/LoginViewController.m
@@ -8,6 +8,7 @@
 #import "LoginViewController.h"
 #import "AboutLauncherViewController.h"
 #import "LauncherFAQViewController.h"
+#import "LauncherPreferences.h"
 
 #include "ios_uikit_bridge.h"
 #include "utils.h"
@@ -243,13 +244,18 @@ void loginAccountInput(UINavigationController *controller, int type, const char*
 }
 
 - (void)loginOffline:(UIButton *)sender {
-    UIAlertController *offlineAlert = [UIAlertController alertControllerWithTitle:@"Offline mode is now Local mode." message:@"You can continue to play installed versions, but you can no longer download Minecraft without a paid account. No support will be provided for issues with local accounts, or other means of acquiring Minecraft. See our website for more information."preferredStyle:UIAlertControllerStyleActionSheet];
-    [self setPopoverProperties:offlineAlert.popoverPresentationController sender:sender];
-    UIAlertAction *ok = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {[self loginUsername:TYPE_OFFLINE];}];
-    UIAlertAction *cancel = [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {[self accountType:sender];}];
-    [self presentViewController:offlineAlert animated:YES completion:nil];
-    [offlineAlert addAction:ok];
-    [offlineAlert addAction:cancel];
+    if ([getPreference(@"local_warn") boolValue] == YES) {
+        UIAlertController *offlineAlert = [UIAlertController alertControllerWithTitle:@"Offline mode is now Local mode." message:@"You can continue to play installed versions, but you can no longer download Minecraft without a paid account. No support will be provided for issues with local accounts, or other means of acquiring Minecraft. See our website for more information."preferredStyle:UIAlertControllerStyleActionSheet];
+        [self setPopoverProperties:offlineAlert.popoverPresentationController sender:sender];
+        UIAlertAction *ok = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {[self loginUsername:TYPE_OFFLINE];}];
+        UIAlertAction *cancel = [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {[self accountType:sender];}];
+        [self presentViewController:offlineAlert animated:YES completion:nil];
+        [offlineAlert addAction:ok];
+        [offlineAlert addAction:cancel];
+        setPreference(@"local_warn", @NO);
+    } else {
+        [self loginUsername:(TYPE_OFFLINE)];
+    }
 }
 
 - (void)loginDemo:(UIButton *)sender {

--- a/Natives/egl_bridge.m
+++ b/Natives/egl_bridge.m
@@ -193,7 +193,7 @@ JNIEXPORT jboolean JNICALL Java_org_lwjgl_glfw_GLFW_nativeEglMakeCurrent(JNIEnv*
         debug("First frame error: %x", eglGetError());
 #endif
         if (success == EGL_TRUE) {
-            GL4ES_HANDLE = dlopen(getenv("GL4ES_LIBNAME"), RTLD_GLOBAL);
+            GL4ES_HANDLE = dlopen(getenv("RENDERER"), RTLD_GLOBAL);
             debug("libGL=%p", GL4ES_HANDLE);
     
             gl4esInitialize_func *gl4esInitialize = (gl4esInitialize_func*) dlsym(GL4ES_HANDLE, "initialize_gl4es");
@@ -202,7 +202,7 @@ JNIEXPORT jboolean JNICALL Java_org_lwjgl_glfw_GLFW_nativeEglMakeCurrent(JNIEnv*
             // gl4esSwapBuffers = (gl4esSwapBuffers_func*) dlsym(GL4ES_HANDLE, "gl4es_SwapBuffers_currentContext");
     
             gl4esInitialize();
-            debug("GL4ES init success");
+            debug("Renderer init success");
         }
 
         // idk this should convert or just `return success;`...


### PR DESCRIPTION
JAVA_HOME and GL4ES_LIBNAME can now be controlled in the Preferences menu of the launcher, although they still require the launcher to be restarted to take effect. Their values are now generated and taken from the plist, and the launcher will default to Java 8 for more compatibility and for the mod installer to work out of the box (if this version is run when the user has Java 8 on the system at all).

TODO: 
- [x] Move JAVA_HOME and GL4ES_LIBNAME
- [x] Add options to the launcher preferences
- [x] Completely remove the need for `custom_env.txt`
- [x] Fix some stuff in the Preferences menu pertaining to the size of the text fields
- [x] Add a warning on the first time viewing the Preferences menu that you need to restart the launcher for some changes to take effect
- [x] Warn the user that they need to select Java 8 for the mod installer to work
- [x] Make a failsafe for if the user enters an invalid JAVA_HOME or GL4ES_LIBNAME, resetting to the default values if an issue launching occurs
- [x] Use nav bar button to allow the user to get more information about settings

Other changes that were done on this branch:
- Java 8 is now preferred when installing PojavLauncher. For right now, this only affects people who use my repository as I'm the only one hosting a copy of Java 8. Currently working to bring Java 8 to Procursus... if I can.
- Made the note about the Local mode change hide after seeing it once. A boolean in the plist can be switched to see it again.
- Boolean to switch the Preferences warning above on to see if again

This is a draft until I get all of the above check boxes marked, most likely within the next few days.