### PR TITLE
Add "slim" builds

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -60,11 +60,17 @@ jobs:
           export NOSTDIN=1 SUDOPASS=$password RUNNER=1
           gmake -j$(sysctl -n hw.ncpu) dsym
 
-      - name: Upload IPA artifact
+      - name: Upload regular ipa
         uses: actions/upload-artifact@v2
         with:
           name: net.kdt.pojavlauncher.ipa
           path: artifacts/net.kdt.pojavlauncher-*.ipa
+
+      - name: Upload slimmed ipa
+        uses: actions/upload-artifact@v2
+        with:
+          name: net.kdt.pojavlauncher.slimmed.ipa
+          path: artifacts/net.kdt.pojavlauncher.slimmed-*.ipa
 
       - name: Upload PojavLauncher.dSYM
         uses: actions/upload-artifact@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,11 +55,17 @@ jobs:
           export NOSTDIN=1 SUDOPASS=$password RUNNER=1
           gmake -j$(sysctl -n hw.ncpu) dsym
 
-      - name: Upload IPA artifact
+      - name: Upload regular ipa
         uses: actions/upload-artifact@v2
         with:
           name: net.kdt.pojavlauncher.ipa
           path: artifacts/net.kdt.pojavlauncher-*.ipa
+
+      - name: Upload slimmed ipa
+        uses: actions/upload-artifact@v2
+        with:
+          name: net.kdt.pojavlauncher.slimmed.ipa
+          path: artifacts/net.kdt.pojavlauncher.slimmed-*.ipa
 
       - name: Upload PojavLauncher.dSYM
         uses: actions/upload-artifact@v2

--- a/Makefile
+++ b/Makefile
@@ -241,7 +241,7 @@ package: native java jre assets
 		sudo chown -R 501:501 Payload; \
 	fi; \
 	zip --symlinks -r $(OUTPUTDIR)/net.kdt.pojavlauncher-$(VERSION).ipa Payload/*
-	zip --symlinks -r $(OUTPUTDIR)/net.kdt.pojavlauncher.slimmed-$(VERSION).ipa Payload/* -x 'Payload/PojavLauncher.app/jvm/java-17-openjdk/*'
+	zip --symlinks -r $(OUTPUTDIR)/net.kdt.pojavlauncher.slimmed-$(VERSION).ipa -x 'Payload/PojavLauncher.app/jvm/java-17-openjdk/*' Payload/*
 	@echo '[PojavLauncher v$(VERSION)] package - end'
 
 dsym: package

--- a/Makefile
+++ b/Makefile
@@ -241,7 +241,7 @@ package: native java jre assets
 		sudo chown -R 501:501 Payload; \
 	fi; \
 	zip --symlinks -r $(OUTPUTDIR)/net.kdt.pojavlauncher-$(VERSION).ipa Payload/
-	zip --symlinks -r $(OUTPUTDIR)/net.kdt.pojavlauncher.slimmed-$(VERSION).ipa Payload/ -x \*java-17-openjdk\* 
+	zip --symlinks -r $(OUTPUTDIR)/net.kdt.pojavlauncher.slimmed-$(VERSION).ipa Payload/ --exclude='Payload/PojavLauncher.app/jvm/java-17-openjdk/*'
 	@echo '[PojavLauncher v$(VERSION)] package - end'
 
 dsym: package

--- a/Makefile
+++ b/Makefile
@@ -240,7 +240,7 @@ package: native java jre assets
 	else \
 		sudo chown -R 501:501 Payload; \
 	fi; \
-	zip --symlinks -r $(OUTPUTDIR)/net.kdt.pojavlauncher-$(VERSION).ipa Payload
+	zip --symlinks -r $(OUTPUTDIR)/net.kdt.pojavlauncher-$(VERSION).ipa Payload; \
 	zip --symlinks -r $(OUTPUTDIR)/net.kdt.pojavlauncher.slimmed-$(VERSION).ipa Payload --exclude='Payload/PojavLauncher.app/jvm/java-17-openjdk/*'
 	@echo '[PojavLauncher v$(VERSION)] package - end'
 

--- a/Makefile
+++ b/Makefile
@@ -240,8 +240,8 @@ package: native java jre assets
 	else \
 		sudo chown -R 501:501 Payload; \
 	fi; \
-	zip --symlinks -r $(OUTPUTDIR)/net.kdt.pojavlauncher-$(VERSION).ipa Payload/
-	zip --symlinks -r $(OUTPUTDIR)/net.kdt.pojavlauncher.slimmed-$(VERSION).ipa Payload/ --exclude='Payload/PojavLauncher.app/jvm/java-17-openjdk/*'
+	zip --symlinks -r $(OUTPUTDIR)/net.kdt.pojavlauncher-$(VERSION).ipa Payload
+	zip --symlinks -r $(OUTPUTDIR)/net.kdt.pojavlauncher.slimmed-$(VERSION).ipa Payload --exclude='Payload/PojavLauncher.app/jvm/java-17-openjdk/*'
 	@echo '[PojavLauncher v$(VERSION)] package - end'
 
 dsym: package

--- a/Makefile
+++ b/Makefile
@@ -240,8 +240,8 @@ package: native java jre assets
 	else \
 		sudo chown -R 501:501 Payload; \
 	fi; \
-	zip --symlinks -r $(OUTPUTDIR)/net.kdt.pojavlauncher-$(VERSION).ipa Payload/*
-	zip --symlinks -r $(OUTPUTDIR)/net.kdt.pojavlauncher.slimmed-$(VERSION).ipa -x 'Payload/PojavLauncher.app/jvm/java-17-openjdk/*' Payload/*
+	zip --symlinks -r $(OUTPUTDIR)/net.kdt.pojavlauncher-$(VERSION).ipa Payload/
+	zip --symlinks -r -x 'Payload/PojavLauncher.app/jvm/java-17-openjdk/*' $(OUTPUTDIR)/net.kdt.pojavlauncher.slimmed-$(VERSION).ipa Payload/
 	@echo '[PojavLauncher v$(VERSION)] package - end'
 
 dsym: package

--- a/Makefile
+++ b/Makefile
@@ -241,7 +241,7 @@ package: native java jre assets
 		sudo chown -R 501:501 Payload; \
 	fi; \
 	zip --symlinks -r $(OUTPUTDIR)/net.kdt.pojavlauncher-$(VERSION).ipa Payload/
-	zip --symlinks -r -x 'Payload/PojavLauncher.app/jvm/java-17-openjdk/*' $(OUTPUTDIR)/net.kdt.pojavlauncher.slimmed-$(VERSION).ipa Payload/
+	zip --symlinks -r $(OUTPUTDIR)/net.kdt.pojavlauncher.slimmed-$(VERSION).ipa Payload/ -x \*java-17-openjdk\* 
 	@echo '[PojavLauncher v$(VERSION)] package - end'
 
 dsym: package

--- a/Makefile
+++ b/Makefile
@@ -241,6 +241,7 @@ package: native java jre assets
 		sudo chown -R 501:501 Payload; \
 	fi; \
 	zip --symlinks -r $(OUTPUTDIR)/net.kdt.pojavlauncher-$(VERSION).ipa Payload/*
+	zip --symlinks -r $(OUTPUTDIR)/net.kdt.pojavlauncher.slimmed-$(VERSION).ipa Payload/* -x 'Payload/PojavLauncher.app/jvm/java-17-openjdk/*'
 	@echo '[PojavLauncher v$(VERSION)] package - end'
 
 dsym: package
@@ -250,12 +251,10 @@ dsym: package
 		echo '$(SUDOPASS)' | sudo -S dsymutil --arch arm64 $(OUTPUTDIR)/Payload/PojavLauncher.app/PojavLauncher; \
 		echo '$(SUDOPASS)' | sudo -S rm -rf $(OUTPUTDIR)/PojavLauncher.dSYM; \
 		echo '$(SUDOPASS)' | sudo -S mv $(OUTPUTDIR)/Payload/PojavLauncher.app/PojavLauncher.dSYM $(OUTPUTDIR)/PojavLauncher.dSYM; \
-		echo '$(SUDOPASS)' | sudo -S rm -rf $(OUTPUTDIR)/Payload; \
 	else \
 		sudo dsymutil --arch arm64 $(OUTPUTDIR)/Payload/PojavLauncher.app/PojavLauncher; \
 		sudo rm -rf $(OUTPUTDIR)/PojavLauncher.dSYM; \
 		sudo mv $(OUTPUTDIR)/Payload/PojavLauncher.app/PojavLauncher.dSYM $(OUTPUTDIR)/PojavLauncher.dSYM; \
-		sudo rm -rf $(OUTPUTDIR)/Payload; \
 	fi
 	@echo '[PojavLauncher v$(VERSION)] dsym - end'
 	

--- a/Natives/JavaLauncher.m
+++ b/Natives/JavaLauncher.m
@@ -93,13 +93,10 @@ NSString* environmentFailsafes(int minVersion) {
     NSString *javaHome = nil;
 
     NSString *jre8Path = [NSString stringWithFormat:@"%@/java-8-openjdk", jvmPath];
-    NSString *jre16Path = [NSString stringWithFormat:@"%@/java-16-openjdk", jvmPath];
     NSString *jre17Path = [NSString stringWithFormat:@"%@/java-17-openjdk", jvmPath];
 
     if ([fm fileExistsAtPath:jre8Path] && minVersion <= 8) {
         javaHome = jre8Path;
-    } else if ([fm fileExistsAtPath:jre16Path] && minVersion <= 16) {
-        javaHome = jre16Path;
     } else if ([fm fileExistsAtPath:jre17Path] && minVersion <= 17) {
         javaHome = jre17Path;
     }

--- a/Natives/LauncherPreferencesViewController.m
+++ b/Natives/LauncherPreferencesViewController.m
@@ -266,7 +266,9 @@ typedef void(^CreateView)(UITableViewCell *, NSString *, NSDictionary *);
                 @"hasDetail": @YES,
                 @"icon": @"cube",
                 @"type": self.typeSwitch,
-                @"enableCondition": whenNotInGame,
+                @"enableCondition": ^BOOL(){
+                    return !getenv("SLIMMED") && whenNotInGame();
+                },
                 // false: 8, true: 17
                 @"customSwitchValue": @[@"java-8-openjdk", @"java-17-openjdk"]
             },

--- a/Natives/main.m
+++ b/Natives/main.m
@@ -302,6 +302,14 @@ void init_setupResolvConf() {
     }
 }
 
+void init_setupSlimmed() {
+    NSString *ipajre = [NSString stringWithFormat:@"%@/jvm/java-17-openjdk", getenv("BUNDLE_PATH")];
+    NSString *sysjre = @"/usr/lib/jvm/java-17-openjdk";
+    if ((![fm fileExistsAtPath:ipajre]) && (![fm fileExistsAtPath:sysjre])) {
+        setenv("SLIMMED", "1", 1);
+    }
+}
+
 int main(int argc, char *argv[]) {
     if (pJLI_Launch) {
         return pJLI_Launch(argc, (const char **)argv,
@@ -325,6 +333,7 @@ int main(int argc, char *argv[]) {
     }
 
     init_checkForJailbreak();
+    init_setupSlimmed();
     
     init_migrateDirIfNecessary();
 

--- a/Natives/utils.m
+++ b/Natives/utils.m
@@ -23,7 +23,7 @@ BOOL getEntitlementValue(NSString *key) {
 }
 
 BOOL isJITEnabled() {
-    if (getEntitlementValue(@"dynamic-codesigning")) {
+    if (getEntitlementValue(@"dynamic-codesigning") || getenv("POJAV_DETECTEDJB")) {
         return YES;
     }
 

--- a/README.md
+++ b/README.md
@@ -1,51 +1,76 @@
-# PojavLauncher
+# PojavLauncher for iOS
 [![Development build](https://github.com/PojavLauncherTeam/PojavLauncher_iOS/actions/workflows/development.yml/badge.svg?branch=main)](https://github.com/PojavLauncherTeam/PojavLauncher_iOS/actions/workflows/development.yml)
 [![Crowdin](https://badges.crowdin.net/pojavlauncher/localized.svg)](https://crowdin.com/project/pojavlauncher)
 [![Discord](https://img.shields.io/discord/724163890803638273.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/x5pxnANzbX)
 [![Reddit](https://img.shields.io/badge/dynamic/json.svg?label=r/PojavLauncher%20member%20count&query=$.data.subscribers&url=https://www.reddit.com/r/PojavLauncher/about.json)](https://reddit.com/r/PojavLauncher)
 
-## Note
-- The official Twitter for PojavLauncher is [@PLaunchTeam](https://twitter.com/PLaunchTeam). Any others (most notably @PojavLauncher) are fake, please report them to Twitter's moderation team.
-
 ## Introduction
-- PojavLauncher is a Minecraft: Java Edition launcher for Android and iOS based on [Boardwalk](https://github.com/zhuowei/Boardwalk).
-- This launcher can launch most of available Minecraft versions (up to latest 1.19.x, including Combat Test versions).
-- Modding via Forge, Fabric, Quilt are also supported.
-- Older versions of Forge and Fabric can be used with OpenJDK 8.
-- This repository contains source code for iOS/iPadOS platform.
-- For Android platform, check out [PojavLauncher repository](https://github.com/PojavLauncherTeam/PojavLauncher).
+PojavLauncher is a Minecraft: Java Edition launcher for Android, iOS, and tvOS, based off of zhouwei's [Boardwalk](https://github.com/zhouwei/Boardwalk) project.
+* Supports most versions of Minecraft: Java Edition, from the very first beta to the newest snapshots.
+* Supports Forge, Fabric, OptiFine, and Quilt to customize the experience with supported mods.
+* Includes customizable on-screen controls, keyboard and mouse, and game controller support.
+* Optimized for jailbroken and TrollStore devices to enable better capabilities.
+* Microsoft and demo mode support for logging into Minecraft.
+* ...and much more!
+
+This repository contains the code for our iOS, iPadOS, and tvOS port of PojavLauncher. Looking for [Android?](https://github.com/PojavLauncherTeam/PojavLauncher)
 
 ## Getting started with PojavLauncher
+The [PojavLauncher Website](https://pojavlauncherteam.github.io/INSTALL.html#ios) has extensive documentation on how to install, set up, and play! For those who wish to install quickly, here's the basics:
 
-The [PojavLauncher Website](https://pojavlauncherteam.github.io/INSTALL.html#ios) has extensive documentation on how to install, set up, and play! For those who wish to install quickly, here's the basics (on iOS 12.2 or later):
+### Requirements
+At the minimum, you'll need one of the following devices on iOS 12.2 or tvOS 14.0 and later:
+- iPhone 6s and later
+- iPad (5th generation) and later
+- iPad Air (2nd generation) and later
+- iPad mini (4th generation) and later
+- iPad Pro (all models)
+- iPod touch (7th generation)
+- Apple TV HD
 
-Note: This is experimental, although game works smoothly, you should not set Render distance too much.
+However, we recommend one of the following devices on iOS or tvOS 14.0 and later:
+- iPhone XS and later, excluding iPhone XR and iPhone SE (2nd generation)
+- iPad (10th generation) and later
+- iPad Air (4th generation) and later
+- iPad mini (6th generation) and later
+- iPad Pro (all models), excluding iPad Pro (9.7-inch)
+- Apple TV 4K (3rd generation)
 
-### Setup the sideload app
-- For iOS 14.0-15.5beta4, [TrollStore](https://github.com/opa334/TrollStore) is recommended to keep PojavLauncher permanently signed and have JIT enabled by itself.
-- Otherwise, install [AltStore](https://altstore.io) or [SideStore](https://github.com/SideStore/SideStore).
-- Other sideloading methods using distribution certificate (without registering UDID) are unsupported as JIT (requires `get-task-allow` entitlement for debugger) is prohibited for distribution.
+Apple TV support is currently in development.
+
+### Setting up to sideload
+PojavLauncher can be sideloaded in many ways. Our recommended solution is to install [TrollStore](https://github.com/opa334/TrollStore) if your iOS version supports it. Installing with TrollStore allows you to permenantly sign the application, automatically enable JIT, and increase memory limits.
+
+If you cannot, [AltStore](https://altstore.io) and [SideStore](https://sidestore.io) are your next best options.
+- SideStore requires iOS 14 and later.
+- Signing services that do not use your UDID (and use distribution certificates) are not supported, as PojavLauncher requires capabilities they do not allow.
+- Only install sideloading software and PojavLauncher from trusted sources. We are not responsible for any harm caused by using unofficial software.
+- Jailbreaks also benefit from permenant signing, autoJIT, and increase memory limits, however we do not recommend them for regular use.
+
 ### Installing PojavLauncher
+#### Release build (TrollStore)
+1. Download an IPA of PojavLauncher in [Releases](https://github.com/PojavLauncherTeam/PojavLauncher_iOS/releases).
+2. Open the package in TrollStore using the share menu.
+
 #### Release build (AltStore/SideStore trusted source)
-- Add `PojavLauncher Repository` from Trusted Sources
-- Tap `FREE` to begin installing.
-#### Development build
-- Download an IPA build of PojavLauncher in the [Actions tab](https://github.com/PojavLauncherTeam/PojavLauncher_iOS/actions).
-- Open the downloaded IPA in the sideload app to install.
+1. Add `PojavLauncher Repository` from the Trusted Sources menu.
+2. Tap `FREE` to begin installing.
+
+#### Nightly builds
+*These builds can contain game-breaking bugs. Use with caution.*
+1. Download an IPA build of PojavLauncher in the [Actions tab](https://github.com/PojavLauncherTeam/PojavLauncher_iOS/actions).
+2. Open the downloaded IPA in your sideloading app to install.
+
 ### Enabling JIT
+PojavLauncher makes use of **just-in-time compilation**, or JIT, to provide usable speeds for the end user. JIT is not supported on iOS without the application being debugged, so workarounds are required to enable it. You can use this chart to determine the best solution for you and your setup.
 | Application         | AltStore | SideStore | TrollStore | JitStreamer | Jitterbug          | Jailbroken |
 |---------------------|----------|-----------|------------|-------------|--------------------|------------|
 | Requires ext-device | Yes      | No        | No         | No          | If VPN unavailable | No         |
 | Requires Wi-Fi      | Yes      | Yes       | No         | Yes         | Yes                | No         |
 | Auto enabled        | Yes(*)   | No        | Yes        | Yes         | No                 | Yes        |
-| Minimum iOS version | 12.2(+)  | 14.0      | 14.0       | 14.0        | 14.0               | 12.2(+)    |
+| Minimum iOS version | 12.2  | 14.0      | 14.0       | 14.0        | 14.0               | 12.2    |
 
-(*) AltServer running in local network is required.  
-(+) iOS 12 and 13 will not be supported in a future PojavLauncher release.
-
-## Known issues
-* Some Forge versions may fail with `java.lang.reflect.InvocationTargetException`.
-* The game will be prone to JetsamEvents. More specifically, random crashes might occurs if allocating too much resources.
+(*) AltServer running in local network is required.
 
 ## Contributors
 PojavLauncher is amazing, and surprisingly stable, and it wouldn't be this way without the commmunity that helped and contribute to the project! Some notable names:


### PR DESCRIPTION
The slim builds allow users to install a smaller version of PojavLauncher with just the Java 8 runtime included. This is useful for those that are limited on storage space, or only play older versions of Minecraft.