### PR TITLE
Add SignTools CI to workflow

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -129,6 +129,13 @@ jobs:
 
       - name: Upload PojavLauncher.dSYM
         uses: actions/upload-artifact@v2
+        
+  #ota:
+  #  name: Upload to OTA server
+  #  needs: build
+  #  runs-on: MacStadium
+  #  steps: idk yet that's why this is commented
+  
         with:
           name: PojavLauncher.dSYM
           path: artifacts/PojavLauncher.dSYM


### PR DESCRIPTION
Pull request to automatically upload build artifacts for signing on my private SignTools server, allowing GitHub builds to be installed over-the-air.

Keeping a device list here to look on and make sure I got all devices that should be added to my developer account.

- [x] `(crystall1nedev) iPad Pro`
- [ ] `(crystall1nedev) iPhone 6s Plus`
- [x] `(crystall1nedev) iPhone SE (1st generation)`
- [x] `(crystall1nedev) iPhone 7`
- [x] `(crystall1nedev) Apple TV 4K`
- [x] `(khanhduytran0)  Apple TV HD`
- [ ] `(khanhduytran0)  iPhone 6s Plus`
- [x] `(khanhduytran0)  iPhone 8 Plus`

Pull request only applies to @khanhduytran0 and I for a few reasons. 
- This is my private SignTools instance hosted on a server that isn't completely public.
- My Apple ID is in use, which could lead to spam and getting it locked by users.
- Installing apps from this instance would require that the device's UDID is added to my Apple Developer account.